### PR TITLE
Distribution directory's name is 'MyApp' not 'myapp'.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,7 @@ lives within the package.  You need to install that package as well:
 
 .. code-block:: text
 
-  $ cd myapp
+  $ cd MyApp
   $ /path/to/python setup.py develop
 
 


### PR DESCRIPTION
Small documentation fix.
